### PR TITLE
feature(list user profiles): implement listing of users if Authenticated

### DIFF
--- a/authors/apps/articles/tests/base_test.py
+++ b/authors/apps/articles/tests/base_test.py
@@ -9,6 +9,7 @@ class TestBaseCase(APITestCase):
         self.login_url = reverse('app_authentication:login')
         self.create_list_article_url = reverse('articles:articles')
         self.get_tags_url = reverse('articles:articles-tags')
+        self.list_users_url = reverse('profiles:profile_list')
         self.test_user = {
             'user': {
                 'username': 'testuser',

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -3,9 +3,9 @@ from rest_framework.generics import (ListCreateAPIView,
                                      CreateAPIView,
                                      RetrieveAPIView,
                                      ListAPIView)
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import (IsAuthenticatedOrReadOnly,
                                         IsAuthenticated)
+from authors.apps.core.pagination import StandardPagination
 from rest_framework.views import APIView
 from .permissions import IsOwnerOrReadonly
 from rest_framework.response import Response
@@ -41,14 +41,7 @@ def get_article(slug):
         article_not_found()
 
 
-class StandardPagination(PageNumberPagination):
-    page_size = 10
-    page_size_query_param = 'page_size'
-    max_page_size = 100
-
-
 class ListCreateArticle(ListCreateAPIView):
-    pagination_class = StandardPagination
     queryset = Article.objects.all()
     renderer_classes = (ArticleJsonRenderer,)
     serializer_class = ArticleSerializers

--- a/authors/apps/core/pagination.py
+++ b/authors/apps/core/pagination.py
@@ -1,0 +1,7 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class StandardPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = 'page_size'
+    max_page_size = 100

--- a/authors/apps/profiles/models.py
+++ b/authors/apps/profiles/models.py
@@ -33,3 +33,6 @@ class Profile(models.Model):
 
     def list_following(self, profile):
         return profile.following.all()
+
+    class Meta:
+        ordering = ['user__username']

--- a/authors/apps/profiles/tests/test_list_profiles.py
+++ b/authors/apps/profiles/tests/test_list_profiles.py
@@ -1,0 +1,24 @@
+from rest_framework.views import status
+from ...articles.tests.base_test import TestBaseCase
+
+
+class TestListUserProfiles(TestBaseCase):
+    def test_authenticated_user_list_profiles(self):
+        self.signup_user()
+        self.signup_user2()
+        token = self.login_user()
+        response = self.client.get(self.list_users_url,
+                                   format='json',
+                                   HTTP_AUTHORIZATION='Token ' + token
+                                   )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("count", response.data)
+        self.assertEqual(response.data['count'], 1)
+
+    def test_unauthenticated_user_list_profiles(self):
+        self.signup_user()
+        self.signup_user2()
+        response = self.client.get(self.list_users_url,
+                                   format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('users/<username>/follow/', views.FollowUnfollow.as_view(), name='follow'),
     path('users/<username>/following/',
          views.Following.as_view(), name='following'),
-    path('users/<username>/followers/', views.FollowedBy.as_view(), name='followers')
+    path('users/<username>/followers/', views.FollowedBy.as_view(), name='followers'),
+    path('profiles/', views.ListProfile.as_view(), name='profile_list')
 
 ]


### PR DESCRIPTION
### What does this PR do?

Have an api endpoint to get all the user profiles for an authenticated user

### Description of Task to be completed?
**Default**
`GET api/v1/profiles/`

**Paginated**
`GET http://127.0.0.1:8000/api/v1/profiles/?page=2&page_size=1`

### How should this be manually tested?
**Run the server:**
`python manage.py runserver`

**From postman:**
    1. Create multiple users by sending  `post` requests to the 'api/v1/users/' endpoint with the data body 

```source-json
    { "user" :{
	"username": "joe",
	"email": "joe@email.com",
	"password": "Joe12345"
}
}
```

2. Retrieve all users by sending a `get` request to the  '/api/v1/profiles/' endpoint

### What are the relevant pivotal tracker stories?
[#162949001](https://www.pivotaltracker.com/story/show/162949001)

### Screenshots
**Default get request (with no parameters set)**
<img width="981" alt="screenshot 2019-01-30 at 20 35 10" src="https://user-images.githubusercontent.com/43740193/52000665-b892c480-24ce-11e9-845d-217cd899f9c7.png">


**get request of the second page and a page_size of one (one user's profile a page)**
<img width="968" alt="screenshot 2019-01-30 at 20 39 06" src="https://user-images.githubusercontent.com/43740193/52000886-3060ef00-24cf-11e9-805e-97b3ea679854.png">

