### PR TITLE
 #162949012 Users should see their articles reading statistics

### DIFF
--- a/authors/apps/articles/migrations/0001_initial.py
+++ b/authors/apps/articles/migrations/0001_initial.py
@@ -22,6 +22,7 @@ class Migration(migrations.Migration):
                 ('title', models.CharField(max_length=1000)),
                 ('description', models.CharField(max_length=2000)),
                 ('body', models.TextField()),
+                ('views', models.IntegerField(default=0, null=True)),
                 ('image_url', models.URLField(blank=True, null=True)),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -80,6 +80,7 @@ class Article(models.Model):
     description = models.CharField(max_length=2000, blank=False)
     body = models.TextField(blank=False)
     tags = models.ManyToManyField('articles.Tag', related_name='articles')
+    views = models.IntegerField(null=True, default=0)
     image_url = models.URLField(blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True, auto_now=False)
     updated_at = models.DateTimeField(auto_now=True, auto_now_add=False)

--- a/authors/apps/articles/tests/base_test.py
+++ b/authors/apps/articles/tests/base_test.py
@@ -205,6 +205,17 @@ class TestBaseCase(APITestCase):
         token = self.login_user2()
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
 
+    def rate_article(self, slug):
+        url = self.rating_url(slug)
+        token = self.login_user2()
+        response = self.client.post(
+            url,
+            self.rating,
+            format="json",
+            HTTP_AUTHORIZATION="Token " + token
+        )
+        return response
+
     def bookmark_article_url(self, slug):
         url = reverse('articles:article-bookmark', kwargs={"slug": slug})
         return url
@@ -233,3 +244,13 @@ class TestBaseCase(APITestCase):
     def article_facebook_share_url(self, slug):
         url = reverse('articles:facebook-share-article', kwargs={"slug": slug})
         return url
+    def view_single_article(self):
+        response = self.client.get(self.single_article_details())
+        return response
+
+    def article_stats(self):
+        token = self.login_user()
+        response = self.client.get(reverse(
+            'articles:article-stats'),
+            HTTP_AUTHORIZATION="Token " + token, format="json")
+        return response

--- a/authors/apps/articles/tests/test_read_stats.py
+++ b/authors/apps/articles/tests/test_read_stats.py
@@ -1,0 +1,80 @@
+from rest_framework import status
+
+from .base_test import TestBaseCase
+
+
+class ReadStatsTest(TestBaseCase):
+    def base_stats(self, data, response):
+        self.assertIn(data.encode(), response.content)
+
+    def http_200_ok(self, response):
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def authorized_post_request(self, url, token):
+        response = self.client.post(
+            url, self.rating, format='json',
+            HTTP_AUTHORIZATION='Token ' + token)
+        return response
+
+    def test_initial_stats_are_zero(self):
+        self.create_article()
+        response = self.article_stats()
+        data = '"view_count": 0'
+        self.base_stats(data, response)
+
+    def test_owner_view_is_not_added_to_stats(self):
+        self.authorize()
+        self.view_single_article()
+
+        response = self.article_stats()
+        self.http_200_ok(response)
+        data = '"view_count": 0'
+        self.base_stats(data, response)
+
+    def test_views_by_different_users_are_added_to_stats(self):
+        token = self.login_user2()
+        slug = self.create_article()
+        url = self.single_article_url(slug)
+        self.client.get(url,
+                        HTTP_AUTHORIZATION="Token " + token, format='json')
+        response = self.article_stats()
+        self.http_200_ok(response)
+        data = '"view_count": 1'
+        self.base_stats(data, response)
+
+    def test_comments_by_same_user_are_added_to_stats(self):
+
+        slug = self.create_article()
+        response = self.add_comment(slug)
+        response = self.article_stats()
+        self.http_200_ok(response)
+        data = '"comment_count": 1'
+        self.base_stats(data, response)
+
+    def test_likes_on_articles_are_added_to_stats(self):
+        token = self.login_user2()
+        slug = self.create_article()
+        url = self.like_arcticle_url(slug)
+        self.authorized_post_request(url, token)
+        response = self.article_stats()
+        self.http_200_ok(response)
+        data = 'likes_count": 1'
+        self.base_stats(data, response)
+
+    def test_dislikes_on_articles_are_added_to_stats(self):
+        token = self.login_user2()
+        slug = self.create_article()
+        url = self.dislike_article_url(slug)
+        self.authorized_post_request(url, token)
+        response = self.article_stats()
+        self.http_200_ok(response)
+        data = 'dislikes_count": 1'
+        self.base_stats(data, response)
+
+    def test_ratings_on_articles_are_added_to_stats(self):
+        slug = self.create_article()
+        self.rate_article(slug)
+        response = self.article_stats()
+        self.http_200_ok(response)
+        data = '"average_rating": 5.0}'
+        self.base_stats(data, response)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -54,5 +54,7 @@ urlpatterns = [
     path('<slug>/share/facebook/', views.ShareArticleViaFacebook.as_view(),
          name="facebook-share-article"),
     path('<slug>/share/twitter/', views.ShareArticleViaTwitter.as_view(),
-         name="twitter-share-article")
+         name="twitter-share-article"),
+    path('statistics/',
+         views.ArticlesStatsView.as_view(), name='article-stats')
 ]


### PR DESCRIPTION
### What does this PR do?
It allows users who are authors of articles to view all statistics for their articles

### Description of the PR?
- Allow users to view a summary of the articles statistics
- Show views, comments, likes, dislikes and the average rating for that specific article
- Don't allow users who are authors of articles to react to their articles

### How should this PR be tested manually
1. Run the server:
`python manage.py runserver`

1. From postman:

    To get an article statistics send  a `GET` request to the '/api/v1/statistics/' end point. 

### Any background context you want to provide?
None

### What are the relevant pivotal tracker stories?
[#162949012](https://www.pivotaltracker.com/story/show/162949012)

### Screenshots
## GET article with no views
<img width="953" alt="screenshot 2019-01-31 at 20 47 24" src="https://user-images.githubusercontent.com/23031493/52074039-0b857e00-259a-11e9-9a3f-8d4599dd3fbb.png">

## GET article with views
<img width="949" alt="screenshot 2019-01-31 at 20 48 25" src="https://user-images.githubusercontent.com/23031493/52074060-1809d680-259a-11e9-8f5f-6790aaf204ac.png">

## GET an article statistics
<img width="972" alt="screenshot 2019-01-31 at 20 51 16" src="https://user-images.githubusercontent.com/23031493/52074099-2821b600-259a-11e9-8383-64215b82ef9d.png">



