### PR TITLE
#163649706 fix follow/unfollow

### DIFF
--- a/authors/apps/profiles/renderers.py
+++ b/authors/apps/profiles/renderers.py
@@ -35,10 +35,10 @@ class FollowUnfollowJsonRenderer(BaseRenderer):
     def render(self, data, accepted_media_type=None, renderer_context=None):
         follow = data.get('follow-detail')
         if follow:
-            return json.dumps({'You are now following {}'.format(data['user']): data})
+            return json.dumps(data)
         unfollow = data.get('unfollow-detail')
         if unfollow:
-            return json.dumps({'You have successfuly unfollowed {}'.format(data['user']): data})
+            return json.dumps(data)
         errors = data.get('errors', None)
         if errors:
             return json.dumps({'Details': data})
@@ -57,10 +57,10 @@ class FollowingFollowrsJsonRenderer(BaseRenderer):
     def render(self, data, accepted_media_type=None, renderer_context=None):
         followers = data.get('followers-detail')
         if followers:
-            return json.dumps({'Here is a list of followers for {}'.format(data['user']): data})
+            return json.dumps(data)
         following = data.get('following-detail')
         if following:
-            return json.dumps({'Here is a list users following {}'.format(data['user']): data})
+            return json.dumps(data)
         errors = data.get('detail', None)
         if errors:
             return json.dumps({'Message': data})

--- a/authors/apps/profiles/tests/test_following.py
+++ b/authors/apps/profiles/tests/test_following.py
@@ -83,7 +83,7 @@ class FollowUnfollowTest(TestBaseCase):
         response = self.client.get(
             self.following_url(),
             HTTP_AUTHORIZATION='Token ' + token, format='json')
-        msesage = 'Here is a list users following testuser'
+        msesage = 'List of authors testuser is following'
         self.response_message_test(msesage, response)
         self.ok_200(response)
 
@@ -93,7 +93,7 @@ class FollowUnfollowTest(TestBaseCase):
         response = self.client.get(
             self.followers_url(),
             HTTP_AUTHORIZATION='Token ' + token, format='json')
-        msesage = 'Here is a list of followers'
+        msesage = 'List of authors following TestUser2'
         self.response_message_test(msesage, response)
         self.ok_200(response)
 

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -113,7 +113,7 @@ class FollowUnfollow(CreateAPIView):
         serialize = self.serializer_class(
             followed_user, context={'request': request})
         data = {
-            'user': username,
+            'message': 'You are now following {}'.format(username),
             'follow-detail': serialize.data
         }
         return Response(data, status=status.HTTP_201_CREATED)
@@ -138,7 +138,7 @@ class FollowUnfollow(CreateAPIView):
         serialize = self.serializer_class(
             followed_user, context={'request': request})
         data = {
-            'user': username,
+            'message': 'You have successfuly unfollowed {}'.format(username),
             'unfollow-detail': serialize.data
         }
         return Response(data, status=status.HTTP_200_OK)
@@ -166,7 +166,7 @@ class Following(RetrieveAPIView):
         serializer = self.serializer_class(
             following, many=True, context={'request': request})
         data = {
-            'user': username,
+            'message': "List of authors {} is following".format(username),
             'following-detail': serializer.data
         }
         return Response(data, status=status.HTTP_200_OK)
@@ -195,7 +195,7 @@ class FollowedBy(RetrieveAPIView):
         serializer = self.serializer_class(
             follower, many=True, context={'request': request})
         data = {
-            'user': username,
+            'message': "List of authors following {}".format(username),
             'followers-detail': serializer.data
         }
         return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
**What does this PR do?**  
- Fix response data for following/unfollowing, and retrieving followers of a user and following of a user

**How should this be manually tested?**

1. Run the server:
`python manage.py runserver`

1. From postman:

    1. Follow an author by sending a `post` request to the '/api/v1/users/`<username>`/follow/' end point. The `username` is the username of the author you wish to follow.

    2. Retrieve a list of all followers of an author has by sending a `get` request to the  '/api/v1/users/`<username>`/followers/' end point
    3. Retrieve a list of all author a user is following by sending a `get` request to the  '/api/v1/users/`<username>`/following/' end point
    4. Unfollow an author by sending a `delete` request to the '/api/v1/users/`<username>`/follow/' end point. The `username` is the username of the author you wish to unfollow.
    
**Any background context you want to provide?**  
None

**What are the relevant pivotal tracker stories?**
[#162948998](https://www.pivotaltracker.com/story/show/162948998)

**Screenshots**
   1. Follow a user
<img width="940" alt="screenshot 2019-02-01 at 15 01 29" src="https://user-images.githubusercontent.com/32098817/52122315-a7af9380-2633-11e9-9948-acffcf67dfcc.png">

   2. Retrieve all followers of a user
<img width="932" alt="screenshot 2019-02-01 at 15 01 46" src="https://user-images.githubusercontent.com/32098817/52122380-dded1300-2633-11e9-92ec-46661b403815.png">

   3. Retrieve all authors a user is following
<img width="937" alt="screenshot 2019-02-01 at 15 01 06" src="https://user-images.githubusercontent.com/32098817/52122403-ee9d8900-2633-11e9-96cc-ddbd6d159f15.png">

   4. Unfollow an author
<img width="940" alt="screenshot 2019-02-01 at 15 01 21" src="https://user-images.githubusercontent.com/32098817/52122415-fb21e180-2633-11e9-970d-b687a78f1cd0.png">

